### PR TITLE
Correct Tom Lehman's Bio's LinkedIn Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
                 </div>
             </div>
             <div class="bio-container">
-                <div class="bio-photo-container"><a href="https://www.linkedin.com/in/ryan-shea-4098b2/"><img src="assets/bios/tom.jpeg" class="bio-photo"></a></div>
+                <div class="bio-photo-container"><a href="https://www.linkedin.com/in/lehmant/"><img src="assets/bios/tom.jpeg" class="bio-photo"></a></div>
                 <div class="bio-text">
                     <p class="bio-name">Tom Lehman</p>
                     <p class="bio-description">Tom is the Co-Founder and CEO of Genius, the most popular music encyclopedia in the world. You might've seen their lyrics on Google or Spotify :)</p>


### PR DESCRIPTION
Fixed bio-container link for Tom Lehman as his bio linked to Ryan Shea's LinkedIn rather than his own, likely a remanent of copy/pasting '.bio-container' elements.